### PR TITLE
Remove deprecated types

### DIFF
--- a/order.go
+++ b/order.go
@@ -236,11 +236,9 @@ type Order struct {
 	Tags                   string                  `json:"tags,omitempty"`
 	LocationId             int64                   `json:"location_id,omitempty"`
 	PaymentGatewayNames    []string                `json:"payment_gateway_names,omitempty"`
-	ProcessingMethod       string                  `json:"processing_method,omitempty"`
 	Refunds                []Refund                `json:"refunds,omitempty"`
 	UserId                 int64                   `json:"user_id,omitempty"`
 	OrderStatusUrl         string                  `json:"order_status_url,omitempty"`
-	Gateway                string                  `json:"gateway,omitempty"`
 	Confirmed              bool                    `json:"confirmed,omitempty"`
 	CheckoutToken          string                  `json:"checkout_token,omitempty"`
 	Reference              string                  `json:"reference,omitempty"`


### PR DESCRIPTION
Removes deprecated types from Order struct. We weren't explicitly sending these fields, but due to how go unmarshalls data, they were being sent as nil to shopify. (Payment method was never in the order struct)


[Linear issue](https://linear.app/officiallyeql/issue/RET-1086/shopify-deprecated-api-fields)

Removing them solves this issue.

Payload after removing (No Gateway, no Payment_Method, no Processing_details:
<img width="1348" alt="294790753-19ceefe8-4ba0-49b5-8d26-28a6519ec4c0" src="https://github.com/OfficiallyEQL/go-shopify/assets/69132277/33e5d067-30ff-4a27-8e2f-cb253d466a21">


Payload before:
<img width="1367" alt="294790790-c071b611-74fc-4554-a860-9c735401669f" src="https://github.com/OfficiallyEQL/go-shopify/assets/69132277/23c9e7d1-f188-48a8-a42d-77f735b870cd">


